### PR TITLE
Adding event bus for decoupling socket.io logic from main game

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,5 +79,8 @@ project(":core") {
         api "io.socket:socket.io-client:2.0.0"
         compileOnly   "org.projectlombok:lombok:1.18.20"
         annotationProcessor 'org.projectlombok:lombok:1.18.20'
+
+        implementation "com.google.dagger:dagger:2.35.1"
+        annotationProcessor "com.google.dagger:dagger-compiler:2.35.1"
     }
 }

--- a/core/src/com/mygdx/game/RazeGame.java
+++ b/core/src/com/mygdx/game/RazeGame.java
@@ -1,18 +1,17 @@
 package com.mygdx.game;
 
 import com.badlogic.gdx.Game;
-import com.badlogic.gdx.graphics.g2d.Batch;
-import com.badlogic.gdx.graphics.g2d.SpriteBatch;
-import com.mygdx.game.screen.ArenaScreen;
+import com.mygdx.game.dagger.component.AppComponent;
+import com.mygdx.game.dagger.component.DaggerAppComponent;
 
 public class RazeGame extends Game {
 
-	private SpriteBatch batch;
+	private AppComponent appComponent;
 	
 	@Override
 	public void create () {
-		batch = new SpriteBatch();
-		this.setScreen(new ArenaScreen(this));
+		appComponent = DaggerAppComponent.create();
+		this.setScreen(appComponent.getArenaScreen());
 	}
 
 	@Override
@@ -22,10 +21,6 @@ public class RazeGame extends Game {
 
 	@Override
 	public void dispose () {
-		batch.dispose();
 	}
 
-	public Batch getBatch() {
-		return batch;
-	}
 }

--- a/core/src/com/mygdx/game/client/SocketIOClient.java
+++ b/core/src/com/mygdx/game/client/SocketIOClient.java
@@ -1,0 +1,179 @@
+package com.mygdx.game.client;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.math.Vector2;
+import com.mygdx.game.constant.AppConstants;
+import com.mygdx.game.constant.SocketEventConstants;
+import com.mygdx.game.constant.State;
+import com.mygdx.game.event.EventBus;
+import com.mygdx.game.event.eventbus.InMemoryEventBus;
+import com.mygdx.game.event.events.*;
+import io.socket.client.IO;
+import io.socket.client.Socket;
+import io.socket.emitter.Emitter;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Client for establishing a connection to the socket io server. Can be used to send messages to the server.
+ * Publishes all messages received from the server to the event bus.
+ */
+public class SocketIOClient {
+
+    private final EventBus eventBus;
+
+    private Socket socket;
+
+    public SocketIOClient() {
+        eventBus = InMemoryEventBus.getInstance();
+        connectSocket();
+        configureSocketEvents();
+    }
+
+    /**
+     * Sends the given message to the socket io server.
+     * @param eventName name of the event
+     * @param payload JSONObject payload
+     */
+    public void emit(final String eventName, final JSONObject payload) {
+        try {
+            socket.emit(eventName, payload);
+        } catch (Exception e) {
+            Gdx.app.error(AppConstants.SOCKET_IO_LOG_TAG, "Error while updating server" , e);
+        }
+    }
+
+    /**
+     * Sends the given message to the socket io server.
+     * @param eventName name of the event
+     * @param payload JSONArray payload
+     */
+    public void emit(final String eventName, final JSONArray payload) {
+        try {
+            socket.emit(eventName, payload);
+        } catch (Exception e) {
+            Gdx.app.error(AppConstants.SOCKET_IO_LOG_TAG, "Error while updating server" , e);
+        }
+    }
+
+    private void connectSocket() {
+        try {
+            socket = IO.socket(AppConstants.SERVER_URL);
+            socket.connect();
+        } catch (Exception e) {
+            Gdx.app.error(AppConstants.SOCKET_IO_LOG_TAG, "Connection Error" , e);
+        }
+    }
+
+    private void configureSocketEvents() {
+        socket.on(SocketEventConstants.CONNECT, getConnectEventListener())
+                .on(SocketEventConstants.SOCKET_ID, getSocketIdEventListener())
+                .on(SocketEventConstants.NEW_PLAYER_CONNECTED, getNewPlayerConnectedEventListener())
+                .on(SocketEventConstants.PLAYER_DISCONNECTED, getPlayerDisconnectedEventListener())
+                .on(SocketEventConstants.GET_PLAYERS, getGetPlayersEventListener())
+                .on(SocketEventConstants.PLAYER_MOVED, getPlayerMovedEventListener());
+    }
+
+    private Emitter.Listener getPlayerMovedEventListener() {
+        return args -> {
+            JSONObject data = (JSONObject) args[0];
+            try {
+                String id = data.getString("id");
+                float x = ((Double) data.getDouble("x")).floatValue();
+                float y = ((Double) data.getDouble("y")).floatValue();
+                boolean flipX = data.getBoolean("flipX");
+                State state = State.valueOf(data.getString("state"));
+
+                eventBus.publish(PlayerMovedEvent.builder()
+                        .playerMovedPayload(PlayerMovedEvent.PlayerMovedPayload.builder()
+                                .id(id)
+                                .position(new Vector2(x, y))
+                                .flipX(flipX)
+                                .state(state)
+                                .build())
+                        .build());
+            } catch (Exception e) {
+                Gdx.app.error(AppConstants.SOCKET_IO_LOG_TAG, "Error while processing player moved", e);
+            }
+        };
+    }
+
+    private Emitter.Listener getGetPlayersEventListener() {
+        return args -> {
+            JSONArray playerInfoList = (JSONArray) args[0];
+            try {
+                List<GetPlayersEvent.GetPlayerPayload> getPlayerPayloadList = new ArrayList<>();
+                for (int i = 0; i < playerInfoList.length(); i++) {
+                    JSONObject playerInfo = (JSONObject) playerInfoList.get(i);
+                    String id = playerInfo.getString("id");
+                    Vector2 position = new Vector2(((Double) playerInfo.getDouble("x")).floatValue(),
+                            ((Double) playerInfo.getDouble("y")).floatValue());
+                    boolean flipX = playerInfo.getBoolean("flipX");
+                    getPlayerPayloadList.add(GetPlayersEvent.GetPlayerPayload.builder()
+                            .id(id)
+                            .position(position)
+                            .flipX(flipX)
+                            .build());
+                }
+                Gdx.app.log(AppConstants.SOCKET_IO_LOG_TAG, "GetPlayers succeeded");
+                eventBus.publish(GetPlayersEvent.builder()
+                        .getPlayerPayloadList(getPlayerPayloadList)
+                        .build());
+            } catch (Exception e) {
+                Gdx.app.error(AppConstants.SOCKET_IO_LOG_TAG, "Error while getting players", e);
+            }
+        };
+    }
+
+    private Emitter.Listener getPlayerDisconnectedEventListener() {
+        return args -> {
+            JSONObject data = (JSONObject) args[0];
+            try {
+                String id = data.getString("id");
+                Gdx.app.log(AppConstants.SOCKET_IO_LOG_TAG, "Player disconnected. Player ID : " + id);
+                eventBus.publish(PlayerDisconnectedEvent.builder()
+                        .id(id)
+                        .build());
+            } catch (Exception e) {
+                Gdx.app.error(AppConstants.SOCKET_IO_LOG_TAG, "Error while getting disconnected player id", e);
+            }
+        };
+    }
+
+    private Emitter.Listener getNewPlayerConnectedEventListener() {
+        return args -> {
+            JSONObject data = (JSONObject) args[0];
+            try {
+                String id = data.getString("id");
+                Gdx.app.log(AppConstants.SOCKET_IO_LOG_TAG, "New player connected. Player ID : " + id);
+                eventBus.publish(NewPlayerConnectedEvent.builder()
+                        .id(id)
+                        .build());
+            } catch (Exception e) {
+                Gdx.app.error(AppConstants.SOCKET_IO_LOG_TAG, "Error while getting new player id", e);
+            }
+        };
+    }
+
+    private Emitter.Listener getSocketIdEventListener() {
+        return args -> {
+            JSONObject data = (JSONObject) args[0];
+            try {
+                String id = data.getString("id");
+                Gdx.app.log(AppConstants.SOCKET_IO_LOG_TAG, "Socket ID : " + id);
+            } catch (Exception e) {
+                Gdx.app.error(AppConstants.SOCKET_IO_LOG_TAG, "Error while getting socket id", e);
+            }
+        };
+    }
+
+    private Emitter.Listener getConnectEventListener() {
+        return args -> {
+            Gdx.app.log(AppConstants.SOCKET_IO_LOG_TAG, "Connected");
+            eventBus.publish(new SocketConnectedEvent());
+        };
+    }
+}

--- a/core/src/com/mygdx/game/client/SocketIOClient.java
+++ b/core/src/com/mygdx/game/client/SocketIOClient.java
@@ -11,9 +11,12 @@ import com.mygdx.game.event.events.*;
 import io.socket.client.IO;
 import io.socket.client.Socket;
 import io.socket.emitter.Emitter;
+import lombok.NonNull;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -21,14 +24,16 @@ import java.util.List;
  * Client for establishing a connection to the socket io server. Can be used to send messages to the server.
  * Publishes all messages received from the server to the event bus.
  */
+@Singleton
 public class SocketIOClient {
 
     private final EventBus eventBus;
 
     private Socket socket;
 
-    public SocketIOClient() {
-        eventBus = InMemoryEventBus.getInstance();
+    @Inject
+    public SocketIOClient(@NonNull final EventBus eventBus) {
+        this.eventBus = eventBus;
         connectSocket();
         configureSocketEvents();
     }

--- a/core/src/com/mygdx/game/constant/AppConstants.java
+++ b/core/src/com/mygdx/game/constant/AppConstants.java
@@ -14,6 +14,8 @@ public final class AppConstants {
 
     public static final String SOCKET_IO_LOG_TAG = "SocketIO";
 
+    public static final String APP_LOG_TAG = APP_NAME;
+
     private AppConstants() {
     }
 }

--- a/core/src/com/mygdx/game/dagger/component/AppComponent.java
+++ b/core/src/com/mygdx/game/dagger/component/AppComponent.java
@@ -1,0 +1,14 @@
+package com.mygdx.game.dagger.component;
+
+import com.mygdx.game.dagger.module.AppModule;
+import com.mygdx.game.screen.ArenaScreen;
+import dagger.Component;
+
+import javax.inject.Singleton;
+
+@Component(modules = AppModule.class)
+@Singleton
+public interface AppComponent {
+
+    ArenaScreen getArenaScreen();
+}

--- a/core/src/com/mygdx/game/dagger/module/AppModule.java
+++ b/core/src/com/mygdx/game/dagger/module/AppModule.java
@@ -1,0 +1,37 @@
+package com.mygdx.game.dagger.module;
+
+import com.badlogic.gdx.graphics.Camera;
+import com.badlogic.gdx.graphics.OrthographicCamera;
+import com.badlogic.gdx.graphics.g2d.Batch;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.mygdx.game.constant.AppConstants;
+import com.mygdx.game.event.EventBus;
+import com.mygdx.game.event.eventbus.InMemoryEventBus;
+import dagger.Module;
+import dagger.Provides;
+
+import javax.inject.Singleton;
+
+@Module
+public class AppModule {
+
+    @Provides
+    @Singleton
+    public Batch provideBatch() {
+        return new SpriteBatch();
+    }
+
+    @Provides
+    @Singleton
+    public Camera provideCamera() {
+        OrthographicCamera camera = new OrthographicCamera();
+        camera.setToOrtho(false, AppConstants.APP_WIDTH, AppConstants.APP_HEIGHT);
+        return camera;
+    }
+
+    @Provides
+    @Singleton
+    public EventBus provideEventBus() {
+        return new InMemoryEventBus();
+    }
+}

--- a/core/src/com/mygdx/game/event/Event.java
+++ b/core/src/com/mygdx/game/event/Event.java
@@ -1,0 +1,14 @@
+package com.mygdx.game.event;
+
+/**
+ * Interface for events to be published to an event bus.
+ * @param <T> the datatype of the event payload
+ */
+public interface Event<T> {
+
+    /**
+     * Returns the event payload.
+     * @return the event payload.
+     */
+    T getPayload();
+}

--- a/core/src/com/mygdx/game/event/EventBus.java
+++ b/core/src/com/mygdx/game/event/EventBus.java
@@ -1,0 +1,19 @@
+package com.mygdx.game.event;
+
+/**
+ * Interface for an event bus which sends published events to subscribed event handler.
+ */
+public interface EventBus {
+
+    /**
+     * Publishes the given event to the event bus.
+     * @param event the event to be published
+     */
+    void publish(final Event<?> event);
+
+    /**
+     * Subscribes the provided event handler to receive events from the event bus.
+     * @param eventHandler the event handler to subscribe
+     */
+    void subscribe(final EventHandler eventHandler);
+}

--- a/core/src/com/mygdx/game/event/EventHandler.java
+++ b/core/src/com/mygdx/game/event/EventHandler.java
@@ -1,0 +1,21 @@
+package com.mygdx.game.event;
+
+import java.util.List;
+
+/**
+ * Interface for classes which want to receive events from an event bus.
+ */
+public interface EventHandler {
+
+    /**
+     * Used by an event bus to filter events by class before sending it to this event handler.
+     * @return List of events this event handler wants to receive from the event bus.
+     */
+    List<Class<?>> getSubscribedEventClasses();
+
+    /**
+     * Called by the event bus with events which have been subscribed to by this event handler.
+     * @param event a subscribed event
+     */
+    void handleEvent(final Event<?> event);
+}

--- a/core/src/com/mygdx/game/event/eventbus/InMemoryEventBus.java
+++ b/core/src/com/mygdx/game/event/eventbus/InMemoryEventBus.java
@@ -4,6 +4,8 @@ import com.mygdx.game.event.Event;
 import com.mygdx.game.event.EventBus;
 import com.mygdx.game.event.EventHandler;
 
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import java.util.*;
 
 /**
@@ -11,19 +13,10 @@ import java.util.*;
  */
 public class InMemoryEventBus implements EventBus {
 
-    private static InMemoryEventBus instance;
-
     private final Map<Class<?>, List<EventHandler>> eventHandlerMap;
 
-    private InMemoryEventBus() {
+    public InMemoryEventBus() {
         eventHandlerMap = new HashMap<>();
-    }
-
-    public static InMemoryEventBus getInstance() {
-        if (Objects.isNull(instance)) {
-            instance = new InMemoryEventBus();
-        }
-        return instance;
     }
 
     @Override

--- a/core/src/com/mygdx/game/event/eventbus/InMemoryEventBus.java
+++ b/core/src/com/mygdx/game/event/eventbus/InMemoryEventBus.java
@@ -1,0 +1,49 @@
+package com.mygdx.game.event.eventbus;
+
+import com.mygdx.game.event.Event;
+import com.mygdx.game.event.EventBus;
+import com.mygdx.game.event.EventHandler;
+
+import java.util.*;
+
+/**
+ * In-memory implementation of event bus.
+ */
+public class InMemoryEventBus implements EventBus {
+
+    private static InMemoryEventBus instance;
+
+    private final Map<Class<?>, List<EventHandler>> eventHandlerMap;
+
+    private InMemoryEventBus() {
+        eventHandlerMap = new HashMap<>();
+    }
+
+    public static InMemoryEventBus getInstance() {
+        if (Objects.isNull(instance)) {
+            instance = new InMemoryEventBus();
+        }
+        return instance;
+    }
+
+    @Override
+    public void publish(final Event<?> event) {
+        if (Objects.nonNull(event) && eventHandlerMap.containsKey(event.getClass())) {
+            eventHandlerMap.get(event.getClass())
+                    .forEach(eventHandler -> eventHandler.handleEvent(event));
+        }
+    }
+
+    @Override
+    public void subscribe(final EventHandler eventHandler) {
+        if (Objects.nonNull(eventHandler)) {
+            eventHandler.getSubscribedEventClasses()
+                    .forEach(clazz -> {
+                        if (!eventHandlerMap.containsKey(clazz)) {
+                            eventHandlerMap.put(clazz, new ArrayList<>());
+                        }
+                        eventHandlerMap.get(clazz).add(eventHandler);
+                    });
+        }
+    }
+}

--- a/core/src/com/mygdx/game/event/events/GetPlayersEvent.java
+++ b/core/src/com/mygdx/game/event/events/GetPlayersEvent.java
@@ -1,0 +1,37 @@
+package com.mygdx.game.event.events;
+
+import com.badlogic.gdx.math.Vector2;
+import com.mygdx.game.event.Event;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Value;
+
+import java.util.List;
+
+/**
+ * Event containing info of all players existing in the world.
+ */
+@Value
+@Builder
+public class GetPlayersEvent implements Event<List<GetPlayersEvent.GetPlayerPayload>> {
+
+    @Getter(AccessLevel.PRIVATE)
+    List<GetPlayerPayload> getPlayerPayloadList;
+
+    @Value
+    @Builder
+    public static class GetPlayerPayload {
+
+        String id;
+
+        Vector2 position;
+
+        boolean flipX;
+    }
+
+    @Override
+    public List<GetPlayerPayload> getPayload() {
+        return getPlayerPayloadList;
+    }
+}

--- a/core/src/com/mygdx/game/event/events/NewPlayerConnectedEvent.java
+++ b/core/src/com/mygdx/game/event/events/NewPlayerConnectedEvent.java
@@ -1,0 +1,23 @@
+package com.mygdx.game.event.events;
+
+import com.mygdx.game.event.Event;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Value;
+
+/**
+ * Event containing the id of the newly connected player.
+ */
+@Value
+@Builder
+public class NewPlayerConnectedEvent implements Event<String> {
+
+    @Getter(AccessLevel.PRIVATE)
+    String id;
+
+    @Override
+    public String getPayload() {
+        return id;
+    }
+}

--- a/core/src/com/mygdx/game/event/events/PlayerDisconnectedEvent.java
+++ b/core/src/com/mygdx/game/event/events/PlayerDisconnectedEvent.java
@@ -1,0 +1,23 @@
+package com.mygdx.game.event.events;
+
+import com.mygdx.game.event.Event;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Value;
+
+/**
+ * Event containing the id of the disconnected player.
+ */
+@Value
+@Builder
+public class PlayerDisconnectedEvent implements Event<String> {
+
+    @Getter(AccessLevel.PRIVATE)
+    String id;
+
+    @Override
+    public String getPayload() {
+        return id;
+    }
+}

--- a/core/src/com/mygdx/game/event/events/PlayerMovedEvent.java
+++ b/core/src/com/mygdx/game/event/events/PlayerMovedEvent.java
@@ -1,0 +1,37 @@
+package com.mygdx.game.event.events;
+
+import com.badlogic.gdx.math.Vector2;
+import com.mygdx.game.constant.State;
+import com.mygdx.game.event.Event;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Value;
+
+/**
+ * Event containing info about a remote player. Also used to send the local player's info to the server.
+ */
+@Value
+@Builder
+public class PlayerMovedEvent implements Event<PlayerMovedEvent.PlayerMovedPayload> {
+
+    @Getter(AccessLevel.PRIVATE)
+    PlayerMovedPayload playerMovedPayload;
+
+    @Value
+    @Builder
+    public static class PlayerMovedPayload {
+        String id;
+
+        Vector2 position;
+
+        boolean flipX;
+
+        State state;
+    }
+
+    @Override
+    public PlayerMovedPayload getPayload() {
+        return playerMovedPayload;
+    }
+}

--- a/core/src/com/mygdx/game/event/events/SocketConnectedEvent.java
+++ b/core/src/com/mygdx/game/event/events/SocketConnectedEvent.java
@@ -1,0 +1,16 @@
+package com.mygdx.game.event.events;
+
+import com.mygdx.game.event.Event;
+import lombok.Value;
+
+/**
+ * Event which signifies that a connection has been established with the server.
+ */
+@Value
+public class SocketConnectedEvent implements Event<Void> {
+
+    @Override
+    public Void getPayload() {
+        return null;
+    }
+}

--- a/core/src/com/mygdx/game/factory/TextureConfigFactory.java
+++ b/core/src/com/mygdx/game/factory/TextureConfigFactory.java
@@ -6,6 +6,10 @@ import com.mygdx.game.model.AnimConfig;
 import com.mygdx.game.model.TextureConfig;
 import com.mygdx.game.util.FluentHashMap;
 
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+@Singleton
 public class TextureConfigFactory {
 
     private static final TextureConfig ELF_WARRIOR_CONFIG = TextureConfig.builder()
@@ -37,6 +41,10 @@ public class TextureConfigFactory {
                     .withEntry(State.MOVING, AnimConfig.builder().name("Elf_03__RUN").frameRate(1/25f).build())
                     .withEntry(State.ATTACKING, AnimConfig.builder().name("Elf_03__ATTACK").frameRate(1/25f).build()))
             .build();
+
+    @Inject
+    public TextureConfigFactory() {
+    }
 
     public TextureConfig getTextureConfigForCharacter(final CharacterType characterType) {
         switch (characterType) {


### PR DESCRIPTION
1. Added Event bus and related interfaces for sending events to and receiving events from the event bus.
2. Moved socket.io logic to SocketIOClient and communicating with game classes via the event bus. This decouples the actual game logic from the socket.io event handling code.
3. Added dagger for dependency injection. This will help us avoid a lot of boiler plate code in constructors.