### PR TITLE
Adding rectangles to characters and modularizing code

### DIFF
--- a/core/src/com/mygdx/game/character/Character.java
+++ b/core/src/com/mygdx/game/character/Character.java
@@ -2,10 +2,14 @@ package com.mygdx.game.character;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.g2d.*;
+import com.badlogic.gdx.math.Rectangle;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.utils.Disposable;
 import com.mygdx.game.constant.State;
+import com.mygdx.game.model.CharacterConfig;
 import com.mygdx.game.model.TextureConfig;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -16,68 +20,83 @@ public class Character implements Disposable {
 
     private final Map<State, Animation<TextureRegion>> stateRegionMap;
 
-    private final Vector2 textureSize;
+    private final CharacterConfig characterConfig;
 
-    private final Vector2 position;
-
-    private final Vector2 previousPosition;
-
+    @Getter
     private final String name;
 
-    private BitmapFont bitmapFont;
+    private final BitmapFont bitmapFont;
 
+    private final Vector2 textureSize;
+
+    @Getter
+    private final Rectangle bounds;
+
+    @Getter
+    private final Rectangle attackArea;
+
+    @Getter
+    @Setter
+    private Vector2 position;
+
+    @Getter
+    @Setter
     private State state;
 
     private State previousState;
 
+    @Getter
+    @Setter
     private boolean flipX;
 
     private float elapsedTime = 0.0f;
 
+    @Getter
+    @Setter
     private boolean canMove;
 
-    public Character(final TextureConfig textureConfig) {
+    public Character(final TextureConfig textureConfig,
+                     final Vector2 position,
+                     final boolean flipX,
+                     final String name,
+                     final CharacterConfig characterConfig) {
         this.textureAtlas = new TextureAtlas(textureConfig.getTexturePath());
         this.stateRegionMap = new HashMap<>();
         textureConfig.getAnimConfigMap().forEach((state, animConfig) -> stateRegionMap.put(state,
                 new Animation<>(animConfig.getFrameRate(), textureAtlas.findRegions(animConfig.getName()))));
-        this.textureSize = new Vector2(textureConfig.getTextureWidth(), textureConfig.getTextureHeight());
-        this.position = new Vector2(0,0);
-        this.previousPosition = new Vector2(getX(), getY());
-        this.state = State.IDLE;
-        this.previousState = State.IDLE;
-        this.canMove = true;
-        this.name = "Player";
-        this.bitmapFont = new BitmapFont(Gdx.files.internal("Skins/glassy/font-export.fnt"));
-    }
-
-    public Character(final TextureConfig textureConfig, final Vector2 position, final boolean flipX, final String name) {
-        this.textureAtlas = new TextureAtlas(textureConfig.getTexturePath());
-        this.stateRegionMap = new HashMap<>();
-        textureConfig.getAnimConfigMap().forEach((state, animConfig) -> stateRegionMap.put(state,
-                new Animation<>(animConfig.getFrameRate(), textureAtlas.findRegions(animConfig.getName()))));
+        this.bounds = new Rectangle(position.x + characterConfig.getBoundsXOffset(),
+                position.y + characterConfig.getBoundsYOffset(),
+                characterConfig.getBoundsWidth(),
+                characterConfig.getBoundsHeight());
+        this.attackArea = new Rectangle(position.x + characterConfig.getAttackAreaXOffset(),
+                position.y + characterConfig.getAttackAreaYOffset(),
+                characterConfig.getAttackAreaWidth(),
+                characterConfig.getAttackAreaHeight());
         this.textureSize = new Vector2(textureConfig.getTextureWidth(), textureConfig.getTextureHeight());
         this.position = position;
-        this.previousPosition = position;
         this.state = State.IDLE;
         this.previousState = State.IDLE;
         this.flipX = flipX;
         this.canMove = true;
         this.name = name;
         this.bitmapFont = new BitmapFont(Gdx.files.internal("Skins/glassy/font-export.fnt"));
+        this.characterConfig = characterConfig;
     }
 
     public void update(final float deltaTime) {
+        bounds.setX(position.x + characterConfig.getBoundsXOffset());
+        bounds.setY(position.y + characterConfig.getBoundsYOffset());
+
         elapsedTime += deltaTime;
-        if (previousPosition.x != getX() || previousPosition.y != getY()) {
-            previousPosition.x = getX();
-            previousPosition.y = getY();
-        }
         if (state != previousState) {
             elapsedTime = 0.0f;
             previousState = state;
         }
         if (State.ATTACKING.equals(state)) {
+            attackArea.setX(flipX ?
+                    position.x + characterConfig.getAttackAreaXOffset() - attackArea.width :
+                    position.x + characterConfig.getAttackAreaXOffset());
+            attackArea.setY(position.y + characterConfig.getAttackAreaYOffset());
             canMove = stateRegionMap.get(state).isAnimationFinished(elapsedTime);
         }
     }
@@ -95,49 +114,5 @@ public class Character implements Disposable {
     public void dispose() {
         textureAtlas.dispose();
         bitmapFont.dispose();
-    }
-
-    public float getX() {
-        return position.x;
-    }
-
-    public float getY() {
-        return position.y;
-    }
-
-    public State getState() {
-        return state;
-    }
-
-    public boolean isFlipX() {
-        return flipX;
-    }
-
-    public boolean isCanMove() {
-        return canMove;
-    }
-
-    public Vector2 getTextureSize() {
-        return textureSize;
-    }
-
-    public void setX(final float x) {
-        position.x = x;
-    }
-
-    public void setY(final float y) {
-        position.y = y;
-    }
-
-    public void setState(final State state) {
-        this.state = state;
-    }
-
-    public void setFlipX(final boolean flipX) {
-        this.flipX = flipX;
-    }
-
-    public void setCanMove(boolean canMove) {
-        this.canMove = canMove;
     }
 }

--- a/core/src/com/mygdx/game/dto/CharacterReadyDto.java
+++ b/core/src/com/mygdx/game/dto/CharacterReadyDto.java
@@ -1,0 +1,39 @@
+package com.mygdx.game.dto;
+
+import com.badlogic.gdx.Gdx;
+import com.mygdx.game.constant.AppConstants;
+import com.mygdx.game.constant.CharacterConstants;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Value;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+@Value
+@Builder
+@Getter(AccessLevel.PRIVATE)
+public class CharacterReadyDto implements Dto {
+
+    CharacterConstants.CharacterType character;
+
+    String name;
+
+    @Override
+    public JSONObject toJsonObject() {
+        try {
+            JSONObject payload = new JSONObject();
+            payload.put("character", character.name());
+            payload.put("name", name);
+            return payload;
+        } catch (Exception e) {
+            Gdx.app.error(AppConstants.APP_LOG_TAG, "Error while converting to json", e);
+            return null;
+        }
+    }
+
+    @Override
+    public JSONArray toJsonArray() {
+        throw new UnsupportedOperationException("Cannot convert this object to JsonArray");
+    }
+}

--- a/core/src/com/mygdx/game/dto/Dto.java
+++ b/core/src/com/mygdx/game/dto/Dto.java
@@ -1,0 +1,11 @@
+package com.mygdx.game.dto;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+public interface Dto {
+
+    JSONObject toJsonObject();
+
+    JSONArray toJsonArray();
+}

--- a/core/src/com/mygdx/game/dto/PlayerMovedDto.java
+++ b/core/src/com/mygdx/game/dto/PlayerMovedDto.java
@@ -1,0 +1,45 @@
+package com.mygdx.game.dto;
+
+import com.badlogic.gdx.Gdx;
+import com.mygdx.game.constant.AppConstants;
+import com.mygdx.game.constant.State;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Value;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+@Value
+@Builder
+@Getter(AccessLevel.PRIVATE)
+public class PlayerMovedDto implements Dto {
+
+    float x;
+
+    float y;
+
+    boolean flipX;
+
+    State state;
+
+    @Override
+    public JSONObject toJsonObject() {
+        try {
+            JSONObject playerData = new JSONObject();
+            playerData.put("x", x);
+            playerData.put("y", y);
+            playerData.put("flipX", flipX);
+            playerData.put("state", state.name());
+            return playerData;
+        } catch (Exception e) {
+            Gdx.app.error(AppConstants.APP_LOG_TAG, "Error while converting to json", e);
+            return null;
+        }
+    }
+
+    @Override
+    public JSONArray toJsonArray() {
+        throw new UnsupportedOperationException("Cannot convert this object to JsonArray");
+    }
+}

--- a/core/src/com/mygdx/game/factory/CharacterConfigFactory.java
+++ b/core/src/com/mygdx/game/factory/CharacterConfigFactory.java
@@ -1,0 +1,39 @@
+package com.mygdx.game.factory;
+
+import com.mygdx.game.constant.CharacterConstants;
+import com.mygdx.game.model.CharacterConfig;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+@Singleton
+public class CharacterConfigFactory {
+
+    private static final CharacterConfig ELF_WARRIOR_CONFIG = CharacterConfig.builder()
+            .boundsXOffset(150f)
+            .boundsYOffset(0f)
+            .boundsWidth(100f)
+            .boundsHeight(100f)
+            .attackAreaXOffset(200f)
+            .attackAreaYOffset(0f)
+            .attackAreaWidth(70f)
+            .attackAreaHeight(100f)
+            .build();
+
+    @Inject
+    public CharacterConfigFactory() {
+    }
+
+    public CharacterConfig getCharacterConfigForCharacter(final CharacterConstants.CharacterType characterType) {
+        switch (characterType) {
+            case ELF_WARRIOR:
+                return ELF_WARRIOR_CONFIG;
+            case ELF_ARCHER:
+                return null; // TODO
+            case ELF_MAGE:
+                return null; // TODO
+            default:
+                throw new IllegalArgumentException("Unexpected value: " + characterType);
+        }
+    }
+}

--- a/core/src/com/mygdx/game/factory/TextureConfigFactory.java
+++ b/core/src/com/mygdx/game/factory/TextureConfigFactory.java
@@ -56,7 +56,7 @@ public class TextureConfigFactory {
             case ELF_MAGE:
                 return ELF_MAGE_CONFIG;
             default:
-                throw new IllegalStateException("Unexpected value: " + characterType);
+                throw new IllegalArgumentException("Unexpected value: " + characterType);
         }
     }
 

--- a/core/src/com/mygdx/game/input/ArenaInputHandler.java
+++ b/core/src/com/mygdx/game/input/ArenaInputHandler.java
@@ -3,8 +3,11 @@ package com.mygdx.game.input;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.math.Vector2;
 import com.mygdx.game.character.Character;
+import com.mygdx.game.constant.AppConstants;
 import com.mygdx.game.constant.State;
+import com.mygdx.game.repository.ConnectedPlayersRepository;
 
 import static com.mygdx.game.constant.CharacterConstants.PLAYER_MOVEMENT_SPEED;
 
@@ -14,9 +17,14 @@ public class ArenaInputHandler implements InputHandler {
 
     private final Texture background;
 
-    public ArenaInputHandler(final Character player, final Texture background) {
+    private final ConnectedPlayersRepository connectedPlayersRepository;
+
+    public ArenaInputHandler(final Character player,
+                             final Texture background,
+                             final ConnectedPlayersRepository connectedPlayersRepository) {
         this.player = player;
         this.background = background;
+        this.connectedPlayersRepository = connectedPlayersRepository;
     }
 
     @Override
@@ -24,32 +32,39 @@ public class ArenaInputHandler implements InputHandler {
         if (Gdx.input.isTouched()) {
             player.setState(State.ATTACKING);
             player.setCanMove(false);
+            connectedPlayersRepository.getConnectedPlayers().forEach((id, character) -> {
+                if (character.getBounds().overlaps(player.getAttackArea())) {
+                    Gdx.app.log(AppConstants.APP_LOG_TAG, String.format("%s attacked %s", player.getName(), character.getName()));
+                    // TODO: Add actual attack logic
+                }
+            });
         }
         if (player.isCanMove()) {
             boolean isMoving = false;
+            Vector2 playerPosition = player.getPosition();
             if (Gdx.input.isKeyPressed(Input.Keys.A)) {
-                if (player.getX() + (-PLAYER_MOVEMENT_SPEED * deltaTime) > 0) {
-                    player.setX(player.getX() + (-PLAYER_MOVEMENT_SPEED * deltaTime));
+                if (player.getBounds().x + (-PLAYER_MOVEMENT_SPEED * deltaTime) > 0) {
+                    playerPosition.x = playerPosition.x + (-PLAYER_MOVEMENT_SPEED * deltaTime);
                 }
                 player.setFlipX(true);
                 isMoving = true;
             }
             if (Gdx.input.isKeyPressed(Input.Keys.D)) {
-                if (player.getX() + player.getTextureSize().x + (PLAYER_MOVEMENT_SPEED * deltaTime) < background.getWidth()) {
-                    player.setX(player.getX() + (PLAYER_MOVEMENT_SPEED * deltaTime));
+                if (player.getBounds().x + player.getBounds().width + (PLAYER_MOVEMENT_SPEED * deltaTime) < background.getWidth()) {
+                    playerPosition.x = playerPosition.x + (PLAYER_MOVEMENT_SPEED * deltaTime);
                 }
                 player.setFlipX(false);
                 isMoving = true;
             }
             if (Gdx.input.isKeyPressed(Input.Keys.W)) {
-                if (player.getY() + player.getTextureSize().y + (PLAYER_MOVEMENT_SPEED * deltaTime) < background.getHeight()) {
-                    player.setY(player.getY() + (PLAYER_MOVEMENT_SPEED * deltaTime));
+                if (player.getBounds().y + player.getBounds().height + (PLAYER_MOVEMENT_SPEED * deltaTime) < background.getHeight()) {
+                    playerPosition.y = playerPosition.y + (PLAYER_MOVEMENT_SPEED * deltaTime);
                 }
                 isMoving = true;
             }
             if (Gdx.input.isKeyPressed(Input.Keys.S)) {
-                if (player.getY() + (-PLAYER_MOVEMENT_SPEED * deltaTime) > 0) {
-                    player.setY(player.getY() + (-PLAYER_MOVEMENT_SPEED * deltaTime));
+                if (player.getBounds().y + (-PLAYER_MOVEMENT_SPEED * deltaTime) > 0) {
+                    playerPosition.y = playerPosition.y + (-PLAYER_MOVEMENT_SPEED * deltaTime);
                 }
                 isMoving = true;
             }

--- a/core/src/com/mygdx/game/model/CharacterConfig.java
+++ b/core/src/com/mygdx/game/model/CharacterConfig.java
@@ -1,0 +1,25 @@
+package com.mygdx.game.model;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class CharacterConfig {
+
+    float boundsXOffset;
+
+    float boundsYOffset;
+
+    float boundsWidth;
+
+    float boundsHeight;
+
+    float attackAreaXOffset;
+
+    float attackAreaYOffset;
+
+    float attackAreaWidth;
+
+    float attackAreaHeight;
+}

--- a/core/src/com/mygdx/game/repository/ConnectedPlayersRepository.java
+++ b/core/src/com/mygdx/game/repository/ConnectedPlayersRepository.java
@@ -1,0 +1,103 @@
+package com.mygdx.game.repository;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.math.Vector2;
+import com.mygdx.game.character.Character;
+import com.mygdx.game.event.Event;
+import com.mygdx.game.event.EventBus;
+import com.mygdx.game.event.EventHandler;
+import com.mygdx.game.event.events.GetPlayersEvent;
+import com.mygdx.game.event.events.NewPlayerConnectedEvent;
+import com.mygdx.game.event.events.PlayerDisconnectedEvent;
+import com.mygdx.game.event.events.PlayerMovedEvent;
+import com.mygdx.game.factory.CharacterConfigFactory;
+import com.mygdx.game.factory.TextureConfigFactory;
+import lombok.Getter;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Singleton
+public class ConnectedPlayersRepository implements EventHandler {
+
+    private static final float NEW_PLAYER_X = 1100;
+
+    private static final float NEW_PLAYER_Y = 780;
+
+    private final TextureConfigFactory textureConfigFactory;
+
+    private final CharacterConfigFactory characterConfigFactory;
+
+    @Getter
+    private final Map<String, Character> connectedPlayers;
+
+    @Inject
+    public ConnectedPlayersRepository(final TextureConfigFactory textureConfigFactory,
+                                      final CharacterConfigFactory characterConfigFactory,
+                                      final EventBus eventBus) {
+        this.textureConfigFactory = textureConfigFactory;
+        this.characterConfigFactory = characterConfigFactory;
+        this.connectedPlayers = new HashMap<>();
+        eventBus.subscribe(this);
+    }
+
+    @Override
+    public List<Class<?>> getSubscribedEventClasses() {
+        return Arrays.asList(NewPlayerConnectedEvent.class,
+                PlayerDisconnectedEvent.class,
+                GetPlayersEvent.class,
+                PlayerMovedEvent.class);
+    }
+
+    @Override
+    public void handleEvent(final Event<?> event) {
+        if (NewPlayerConnectedEvent.class == event.getClass()) {
+            handleNewPlayerConnected((NewPlayerConnectedEvent) event);
+        } else if (PlayerDisconnectedEvent.class == event.getClass()) {
+            handlePlayerDisconnected((PlayerDisconnectedEvent) event);
+        } else if (GetPlayersEvent.class == event.getClass()) {
+            handleGetPlayers((GetPlayersEvent) event);
+        } else if (PlayerMovedEvent.class == event.getClass()) {
+            handlePlayerMoved((PlayerMovedEvent) event);
+        }
+    }
+
+    private void handlePlayerMoved(final PlayerMovedEvent event) {
+        PlayerMovedEvent.PlayerMovedPayload playerMovedPayload = event.getPayload();
+        if (connectedPlayers.containsKey(playerMovedPayload.getId())) {
+            Character otherPlayer = connectedPlayers.get(playerMovedPayload.getId());
+            otherPlayer.getPosition().x = playerMovedPayload.getPosition().x;
+            otherPlayer.getPosition().y = playerMovedPayload.getPosition().y;
+            otherPlayer.setFlipX(playerMovedPayload.isFlipX());
+            if (otherPlayer.isCanMove()) {
+                otherPlayer.setState(playerMovedPayload.getState());
+            }
+        }
+    }
+
+    private void handleGetPlayers(final GetPlayersEvent event) {
+        List<GetPlayersEvent.GetPlayerPayload> getPlayerPayloadList = event.getPayload();
+        getPlayerPayloadList.forEach(getPlayerPayload ->
+                Gdx.app.postRunnable(() ->
+                        connectedPlayers.put(getPlayerPayload.getId(),
+                                new Character(textureConfigFactory.getTextureConfigForCharacter(getPlayerPayload.getCharacterType()),
+                                        getPlayerPayload.getPosition(), getPlayerPayload.isFlipX(), getPlayerPayload.getName(),
+                                        characterConfigFactory.getCharacterConfigForCharacter(getPlayerPayload.getCharacterType())))));
+    }
+
+    private void handlePlayerDisconnected(final PlayerDisconnectedEvent event) {
+        connectedPlayers.remove(event.getPayload());
+    }
+
+    private void handleNewPlayerConnected(final NewPlayerConnectedEvent event) {
+        Gdx.app.postRunnable(() ->
+                connectedPlayers.put(event.getPayload().getId(),
+                        new Character(textureConfigFactory.getTextureConfigForCharacter(event.getPayload().getCharacterType()),
+                                new Vector2(NEW_PLAYER_X, NEW_PLAYER_Y), false, event.getPayload().getName(),
+                                characterConfigFactory.getCharacterConfigForCharacter(event.getPayload().getCharacterType()))));
+    }
+}

--- a/core/src/com/mygdx/game/screen/ArenaScreen.java
+++ b/core/src/com/mygdx/game/screen/ArenaScreen.java
@@ -1,6 +1,5 @@
 package com.mygdx.game.screen;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Screen;
 import com.badlogic.gdx.graphics.Camera;
 import com.badlogic.gdx.graphics.Texture;
@@ -9,25 +8,25 @@ import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.utils.ScreenUtils;
 import com.mygdx.game.character.Character;
 import com.mygdx.game.client.SocketIOClient;
+import com.mygdx.game.dto.CharacterReadyDto;
+import com.mygdx.game.dto.PlayerMovedDto;
 import com.mygdx.game.constant.AppConstants;
 import com.mygdx.game.constant.CharacterConstants;
 import com.mygdx.game.constant.SocketEventConstants;
-import com.mygdx.game.event.Event;
-import com.mygdx.game.event.EventBus;
-import com.mygdx.game.event.EventHandler;
-import com.mygdx.game.event.events.*;
+import com.mygdx.game.factory.CharacterConfigFactory;
 import com.mygdx.game.factory.TextureConfigFactory;
 import com.mygdx.game.input.ArenaInputHandler;
 import com.mygdx.game.input.InputHandler;
+import com.mygdx.game.repository.ConnectedPlayersRepository;
 import lombok.NonNull;
-import org.json.JSONObject;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.util.*;
+import java.util.Map;
+import java.util.Objects;
 
 @Singleton
-public class ArenaScreen implements Screen, EventHandler {
+public class ArenaScreen implements Screen {
 
     private final Batch batch;
 
@@ -35,9 +34,11 @@ public class ArenaScreen implements Screen, EventHandler {
 
     private final TextureConfigFactory textureConfigFactory;
 
-    private final Map<String, Character> connectedPlayers;
-
     private final SocketIOClient socketIOClient;
+
+    private final ConnectedPlayersRepository connectedPlayersRepository;
+
+    private final CharacterConfigFactory characterConfigFactory;
 
     private final Texture background;
 
@@ -52,14 +53,15 @@ public class ArenaScreen implements Screen, EventHandler {
                        @NonNull final Camera camera,
                        @NonNull final TextureConfigFactory textureConfigFactory,
                        @NonNull final SocketIOClient socketIOClient,
-                       @NonNull final EventBus eventBus) {
+                       @NonNull final ConnectedPlayersRepository connectedPlayersRepository,
+                       @NonNull final CharacterConfigFactory characterConfigFactory) {
         this.batch = batch;
         this.camera = camera;
         this.textureConfigFactory = textureConfigFactory;
         this.socketIOClient = socketIOClient;
-        this.connectedPlayers = new HashMap<>();
+        this.connectedPlayersRepository = connectedPlayersRepository;
+        this.characterConfigFactory = characterConfigFactory;
         this.background = new Texture("Background/game_background_4.png"); //TODO : Refactor this
-        eventBus.subscribe(this);
     }
 
     /**
@@ -68,16 +70,14 @@ public class ArenaScreen implements Screen, EventHandler {
      */
     public void initializePlayer(final CharacterConstants.CharacterType characterType, final String characterName) {
         player = new Character(textureConfigFactory.getTextureConfigForCharacter(characterType),
-                new Vector2(camera.viewportWidth, camera.viewportHeight), false, characterName);
-        inputHandler = new ArenaInputHandler(player, background);
-        try {
-            JSONObject payload = new JSONObject();
-            payload.put("character", characterType.name());
-            payload.put("name", characterName);
-            socketIOClient.emit(SocketEventConstants.PLAYER_READY, payload);
-        } catch (Exception e) {
-            Gdx.app.log(AppConstants.APP_LOG_TAG, "Error while sending event to server", e);
-        }
+                new Vector2(camera.viewportWidth, camera.viewportHeight), false, characterName,
+                characterConfigFactory.getCharacterConfigForCharacter(characterType));
+        inputHandler = new ArenaInputHandler(player, background, connectedPlayersRepository);
+        CharacterReadyDto dto = CharacterReadyDto.builder()
+                .name(characterName)
+                .character(characterType)
+                .build();
+        socketIOClient.emit(SocketEventConstants.PLAYER_READY, dto.toJsonObject());
     }
 
     @Override
@@ -94,7 +94,7 @@ public class ArenaScreen implements Screen, EventHandler {
         batch.begin();
         if (Objects.nonNull(player)) {
             batch.draw(background, 0, 0);
-            for (Map.Entry<String, Character> characterEntry : connectedPlayers.entrySet()) {
+            for (Map.Entry<String, Character> characterEntry : connectedPlayersRepository.getConnectedPlayers().entrySet()) {
                 characterEntry.getValue().draw(batch);
             }
             player.draw(batch);
@@ -107,7 +107,7 @@ public class ArenaScreen implements Screen, EventHandler {
             inputHandler.handleInput(delta);
             player.update(delta);
 
-            for (Map.Entry<String, Character> characterEntry : connectedPlayers.entrySet()) {
+            for (Map.Entry<String, Character> characterEntry : connectedPlayersRepository.getConnectedPlayers().entrySet()) {
                 characterEntry.getValue().update(delta);
             }
         }
@@ -115,11 +115,11 @@ public class ArenaScreen implements Screen, EventHandler {
 
     private void updateCamera(float delta) {
         if (Objects.nonNull(player)) {
-            float nextX = player.getX() + (player.getTextureSize().x / 2);
+            float nextX = player.getBounds().x + (player.getBounds().width / 2);
             if (nextX - (camera.viewportWidth / 2) > 0 && nextX + (camera.viewportWidth / 2) < background.getWidth()) {
                 camera.position.x = nextX;
             }
-            float nextY = player.getY() + (player.getTextureSize().y / 2);
+            float nextY = player.getBounds().y + (player.getBounds().height / 2);
             if (nextY - (camera.viewportHeight/2) > 0 && nextY + (camera.viewportHeight/2) < background.getHeight()) {
                 camera.position.y = nextY;
             }
@@ -130,24 +130,21 @@ public class ArenaScreen implements Screen, EventHandler {
     private void updateServer(float delta) {
         timeSinceLastServerUpdate += delta;
         if (timeSinceLastServerUpdate >= AppConstants.SERVER_UPDATE_RATE && Objects.nonNull(player)) {
-            try {
-                JSONObject playerData = new JSONObject();
-                playerData.put("x", player.getX());
-                playerData.put("y", player.getY());
-                playerData.put("flipX", player.isFlipX());
-                playerData.put("state", player.getState().name());
-                socketIOClient.emit(SocketEventConstants.PLAYER_MOVED, playerData);
-                timeSinceLastServerUpdate = 0f;
-            } catch (Exception e) {
-                Gdx.app.error(AppConstants.APP_LOG_TAG, "Error while updating server" , e);
-            }
+            PlayerMovedDto dto = PlayerMovedDto.builder()
+                        .x(player.getPosition().x)
+                        .y(player.getPosition().y)
+                        .flipX(player.isFlipX())
+                        .state(player.getState())
+                        .build();
+            socketIOClient.emit(SocketEventConstants.PLAYER_MOVED, dto.toJsonObject());
+            timeSinceLastServerUpdate = 0f;
         }
     }
 
     @Override
     public void dispose() {
         player.dispose();
-        for (Map.Entry<String, Character> characterEntry : connectedPlayers.entrySet()) {
+        for (Map.Entry<String, Character> characterEntry : connectedPlayersRepository.getConnectedPlayers().entrySet()) {
             characterEntry.getValue().dispose();
         }
         background.dispose();
@@ -171,59 +168,5 @@ public class ArenaScreen implements Screen, EventHandler {
 
     @Override
     public void resize(int width, int height) {
-    }
-
-    @Override
-    public List<Class<?>> getSubscribedEventClasses() {
-        return Arrays.asList(NewPlayerConnectedEvent.class,
-                PlayerDisconnectedEvent.class,
-                GetPlayersEvent.class,
-                PlayerMovedEvent.class);
-    }
-
-    @Override
-    public void handleEvent(final Event<?> event) {
-        if (NewPlayerConnectedEvent.class == event.getClass()) {
-            handleNewPlayerConnected((NewPlayerConnectedEvent) event);
-        } else if (PlayerDisconnectedEvent.class == event.getClass()) {
-            handlePlayerDisconnected((PlayerDisconnectedEvent) event);
-        } else if (GetPlayersEvent.class == event.getClass()) {
-            handleGetPlayers((GetPlayersEvent) event);
-        } else if (PlayerMovedEvent.class == event.getClass()) {
-            handlePlayerMoved((PlayerMovedEvent) event);
-        }
-    }
-
-    private void handlePlayerMoved(final PlayerMovedEvent event) {
-        PlayerMovedEvent.PlayerMovedPayload playerMovedPayload = event.getPayload();
-        if (connectedPlayers.containsKey(playerMovedPayload.getId())) {
-            Character otherPlayer = connectedPlayers.get(playerMovedPayload.getId());
-            otherPlayer.setX(playerMovedPayload.getPosition().x);
-            otherPlayer.setY(playerMovedPayload.getPosition().y);
-            otherPlayer.setFlipX(playerMovedPayload.isFlipX());
-            if (otherPlayer.isCanMove()) {
-                otherPlayer.setState(playerMovedPayload.getState());
-            }
-        }
-    }
-
-    private void handleGetPlayers(final GetPlayersEvent event) {
-        List<GetPlayersEvent.GetPlayerPayload> getPlayerPayloadList = event.getPayload();
-        getPlayerPayloadList.forEach(getPlayerPayload ->
-                Gdx.app.postRunnable(() ->
-                        connectedPlayers.put(getPlayerPayload.getId(),
-                                new Character(textureConfigFactory.getTextureConfigForCharacter(getPlayerPayload.getCharacterType()),
-                                        getPlayerPayload.getPosition(), getPlayerPayload.isFlipX(), getPlayerPayload.getName()))));
-    }
-
-    private void handlePlayerDisconnected(final PlayerDisconnectedEvent event) {
-        connectedPlayers.remove(event.getPayload());
-    }
-
-    private void handleNewPlayerConnected(final NewPlayerConnectedEvent event) {
-        Gdx.app.postRunnable(() ->
-                connectedPlayers.put(event.getPayload().getId(),
-                        new Character(textureConfigFactory.getTextureConfigForCharacter(event.getPayload().getCharacterType()),
-                                new Vector2(camera.viewportWidth, camera.viewportHeight), false, event.getPayload().getName())));
     }
 }


### PR DESCRIPTION
1. Moving logic for managing connected players to `ConnectedPlayersRepository` and making it an event handler instead of `ArenaScreen`.
2. Adding rectangles to `Character` for bounds and attackArea. These will be used for determining collisions. Also, removed explicit getters and setters for fields and added lombok annotations. Also removed unused fields and constructors.
3. Modified movement logic to use character bounds instead of textureSize.
4. Added DTO objects to encapsulate json creation logic.