### PR TITLE
Adding logic for attacking, taking damage and death of players

### DIFF
--- a/core/src/com/mygdx/game/RazeGame.java
+++ b/core/src/com/mygdx/game/RazeGame.java
@@ -42,8 +42,6 @@ public class RazeGame extends Game implements EventHandler {
 		if (CharacterSelectedEvent.class == event.getClass()) {
 			ArenaScreen arenaScreen = appComponent.getArenaScreen();
 			this.setScreen(arenaScreen);
-			CharacterSelectedEvent.CharacterSelectedPayload payload = ((CharacterSelectedEvent) event).getPayload();
-			arenaScreen.initializePlayer(payload.getCharacter(), payload.getName());
 		}
 	}
 }

--- a/core/src/com/mygdx/game/character/Character.java
+++ b/core/src/com/mygdx/game/character/Character.java
@@ -6,6 +6,7 @@ import com.badlogic.gdx.math.Rectangle;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.utils.Disposable;
 import com.mygdx.game.constant.AppConstants;
+import com.mygdx.game.constant.CharacterConstants;
 import com.mygdx.game.constant.State;
 import com.mygdx.game.model.CharacterConfig;
 import com.mygdx.game.model.CharacterStats;
@@ -26,6 +27,9 @@ public class Character implements Disposable {
 
     @Getter
     private final CharacterStats currentStats;
+
+    @Getter
+    private final CharacterConstants.CharacterType characterType;
 
     @Getter
     private final String name;
@@ -64,7 +68,8 @@ public class Character implements Disposable {
                      final Vector2 position,
                      final boolean flipX,
                      final String name,
-                     final CharacterConfig characterConfig) {
+                     final CharacterConfig characterConfig,
+                     final CharacterConstants.CharacterType characterType) {
         this.textureAtlas = new TextureAtlas(textureConfig.getTexturePath());
         this.stateRegionMap = new HashMap<>();
         textureConfig.getAnimConfigMap().forEach((state, animConfig) -> stateRegionMap.put(state,
@@ -91,6 +96,7 @@ public class Character implements Disposable {
                 .attack(characterConfig.getCharacterStats().getAttack())
                 .defense(characterConfig.getCharacterStats().getDefense())
                 .build();
+        this.characterType = characterType;
     }
 
     public void update(final float deltaTime) {

--- a/core/src/com/mygdx/game/constant/SocketEventConstants.java
+++ b/core/src/com/mygdx/game/constant/SocketEventConstants.java
@@ -18,6 +18,10 @@ public final class SocketEventConstants {
 
     public static final String PLAYER_READY = "playerReady";
 
+    public static final String PLAYER_DAMAGED = "playerDamaged";
+
+    public static final String TAKE_DAMAGE = "takeDamage";
+
     private SocketEventConstants() {
     }
 }

--- a/core/src/com/mygdx/game/constant/State.java
+++ b/core/src/com/mygdx/game/constant/State.java
@@ -1,5 +1,5 @@
 package com.mygdx.game.constant;
 
 public enum State {
-    IDLE, MOVING, ATTACKING
+    IDLE, MOVING, ATTACKING, TAKING_DAMAGE, DEAD
 }

--- a/core/src/com/mygdx/game/dto/PlayerDamagedDto.java
+++ b/core/src/com/mygdx/game/dto/PlayerDamagedDto.java
@@ -1,0 +1,38 @@
+package com.mygdx.game.dto;
+
+import com.badlogic.gdx.Gdx;
+import com.mygdx.game.constant.AppConstants;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Value;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+@Value
+@Builder
+@Getter(AccessLevel.PRIVATE)
+public class PlayerDamagedDto implements Dto {
+
+    String id;
+
+    int damage;
+
+    @Override
+    public JSONObject toJsonObject() {
+        try {
+            JSONObject data = new JSONObject();
+            data.put("id", id);
+            data.put("damage", damage);
+            return data;
+        } catch (Exception e) {
+            Gdx.app.error(AppConstants.APP_LOG_TAG, "Error while converting to json", e);
+            return null;
+        }
+    }
+
+    @Override
+    public JSONArray toJsonArray() {
+        throw new UnsupportedOperationException("Cannot convert this object to JsonArray");
+    }
+}

--- a/core/src/com/mygdx/game/event/events/TakeDamageEvent.java
+++ b/core/src/com/mygdx/game/event/events/TakeDamageEvent.java
@@ -1,0 +1,30 @@
+package com.mygdx.game.event.events;
+
+import com.mygdx.game.event.Event;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Value;
+
+@Value
+@Builder
+public class TakeDamageEvent implements Event<TakeDamageEvent.TakeDamageEventPayload> {
+
+    @Value
+    @Builder
+    public static class TakeDamageEventPayload {
+        String id;
+
+        int damage;
+
+        boolean localPlayer;
+    }
+
+    @Getter(AccessLevel.PRIVATE)
+    TakeDamageEventPayload takeDamageEventPayload;
+
+    @Override
+    public TakeDamageEventPayload getPayload() {
+        return takeDamageEventPayload;
+    }
+}

--- a/core/src/com/mygdx/game/factory/CharacterConfigFactory.java
+++ b/core/src/com/mygdx/game/factory/CharacterConfigFactory.java
@@ -2,6 +2,7 @@ package com.mygdx.game.factory;
 
 import com.mygdx.game.constant.CharacterConstants;
 import com.mygdx.game.model.CharacterConfig;
+import com.mygdx.game.model.CharacterStats;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -18,6 +19,11 @@ public class CharacterConfigFactory {
             .attackAreaYOffset(0f)
             .attackAreaWidth(70f)
             .attackAreaHeight(100f)
+            .characterStats(CharacterStats.builder()
+                    .attack(30)
+                    .defense(20)
+                    .health(100)
+                    .build())
             .build();
 
     private static final CharacterConfig ELF_ARCHER_CONFIG = CharacterConfig.builder()
@@ -29,6 +35,11 @@ public class CharacterConfigFactory {
             .attackAreaYOffset(0f)
             .attackAreaWidth(180f)
             .attackAreaHeight(100f)
+            .characterStats(CharacterStats.builder()
+                    .attack(15)
+                    .defense(10)
+                    .health(60)
+                    .build())
             .build();
 
     private static final CharacterConfig ELF_MAGE_CONFIG = CharacterConfig.builder()
@@ -40,6 +51,11 @@ public class CharacterConfigFactory {
             .attackAreaYOffset(0f)
             .attackAreaWidth(150f)
             .attackAreaHeight(100f)
+            .characterStats(CharacterStats.builder()
+                    .attack(20)
+                    .defense(5)
+                    .health(80)
+                    .build())
             .build();
 
     @Inject

--- a/core/src/com/mygdx/game/factory/TextureConfigFactory.java
+++ b/core/src/com/mygdx/game/factory/TextureConfigFactory.java
@@ -20,7 +20,8 @@ public class TextureConfigFactory {
             .animConfigMap(new FluentHashMap<State, AnimConfig>()
                     .withEntry(State.IDLE, AnimConfig.builder().name("Elf_02__IDLE").frameRate(1/25f).build())
                     .withEntry(State.MOVING, AnimConfig.builder().name("Elf_02__RUN").frameRate(1/25f).build())
-                    .withEntry(State.ATTACKING, AnimConfig.builder().name("Elf_02__ATTACK").frameRate(1/25f).build()))
+                    .withEntry(State.ATTACKING, AnimConfig.builder().name("Elf_02__ATTACK").frameRate(1/25f).build())
+                    .withEntry(State.DEAD, AnimConfig.builder().name("Elf_02__DIE").frameRate(1/25f).build()))
             .build();
 
     private static final TextureConfig ELF_ARCHER_CONFIG = TextureConfig.builder()
@@ -30,7 +31,8 @@ public class TextureConfigFactory {
             .animConfigMap(new FluentHashMap<State, AnimConfig>()
                     .withEntry(State.IDLE, AnimConfig.builder().name("Elf_01__IDLE").frameRate(1/25f).build())
                     .withEntry(State.MOVING, AnimConfig.builder().name("Elf_01__RUN").frameRate(1/25f).build())
-                    .withEntry(State.ATTACKING, AnimConfig.builder().name("Elf_01__ATTACK").frameRate(1/25f).build()))
+                    .withEntry(State.ATTACKING, AnimConfig.builder().name("Elf_01__ATTACK").frameRate(1/25f).build())
+                    .withEntry(State.DEAD, AnimConfig.builder().name("Elf_01__DIE").frameRate(1/25f).build()))
             .build();
 
     private static final TextureConfig ELF_MAGE_CONFIG = TextureConfig.builder()
@@ -40,7 +42,8 @@ public class TextureConfigFactory {
             .animConfigMap(new FluentHashMap<State, AnimConfig>()
                     .withEntry(State.IDLE, AnimConfig.builder().name("Elf_03__IDLE").frameRate(1/25f).build())
                     .withEntry(State.MOVING, AnimConfig.builder().name("Elf_03__RUN").frameRate(1/25f).build())
-                    .withEntry(State.ATTACKING, AnimConfig.builder().name("Elf_03__ATTACK").frameRate(1/25f).build()))
+                    .withEntry(State.ATTACKING, AnimConfig.builder().name("Elf_03__ATTACK").frameRate(1/25f).build())
+                    .withEntry(State.DEAD, AnimConfig.builder().name("Elf_03__DIE").frameRate(1/25f).build()))
             .build();
 
     @Inject

--- a/core/src/com/mygdx/game/model/CharacterConfig.java
+++ b/core/src/com/mygdx/game/model/CharacterConfig.java
@@ -22,4 +22,6 @@ public class CharacterConfig {
     float attackAreaWidth;
 
     float attackAreaHeight;
+
+    CharacterStats characterStats;
 }

--- a/core/src/com/mygdx/game/model/CharacterStats.java
+++ b/core/src/com/mygdx/game/model/CharacterStats.java
@@ -1,0 +1,15 @@
+package com.mygdx.game.model;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class CharacterStats {
+
+    int health;
+
+    int attack;
+
+    int defense;
+}

--- a/core/src/com/mygdx/game/repository/ConnectedPlayersRepository.java
+++ b/core/src/com/mygdx/game/repository/ConnectedPlayersRepository.java
@@ -96,7 +96,8 @@ public class ConnectedPlayersRepository implements EventHandler {
                         connectedPlayers.put(getPlayerPayload.getId(),
                                 new Character(textureConfigFactory.getTextureConfigForCharacter(getPlayerPayload.getCharacterType()),
                                         getPlayerPayload.getPosition(), getPlayerPayload.isFlipX(), getPlayerPayload.getName(),
-                                        characterConfigFactory.getCharacterConfigForCharacter(getPlayerPayload.getCharacterType())))));
+                                        characterConfigFactory.getCharacterConfigForCharacter(getPlayerPayload.getCharacterType()),
+                                        getPlayerPayload.getCharacterType()))));
     }
 
     private void handlePlayerDisconnected(final PlayerDisconnectedEvent event) {
@@ -113,6 +114,7 @@ public class ConnectedPlayersRepository implements EventHandler {
                 connectedPlayers.put(event.getPayload().getId(),
                         new Character(textureConfigFactory.getTextureConfigForCharacter(event.getPayload().getCharacterType()),
                                 new Vector2(NEW_PLAYER_X, NEW_PLAYER_Y), false, event.getPayload().getName(),
-                                characterConfigFactory.getCharacterConfigForCharacter(event.getPayload().getCharacterType()))));
+                                characterConfigFactory.getCharacterConfigForCharacter(event.getPayload().getCharacterType()),
+                                event.getPayload().getCharacterType())));
     }
 }

--- a/core/src/com/mygdx/game/repository/ConnectedPlayersRepository.java
+++ b/core/src/com/mygdx/game/repository/ConnectedPlayersRepository.java
@@ -3,13 +3,11 @@ package com.mygdx.game.repository;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.math.Vector2;
 import com.mygdx.game.character.Character;
+import com.mygdx.game.constant.State;
 import com.mygdx.game.event.Event;
 import com.mygdx.game.event.EventBus;
 import com.mygdx.game.event.EventHandler;
-import com.mygdx.game.event.events.GetPlayersEvent;
-import com.mygdx.game.event.events.NewPlayerConnectedEvent;
-import com.mygdx.game.event.events.PlayerDisconnectedEvent;
-import com.mygdx.game.event.events.PlayerMovedEvent;
+import com.mygdx.game.event.events.*;
 import com.mygdx.game.factory.CharacterConfigFactory;
 import com.mygdx.game.factory.TextureConfigFactory;
 import lombok.Getter;
@@ -50,7 +48,8 @@ public class ConnectedPlayersRepository implements EventHandler {
         return Arrays.asList(NewPlayerConnectedEvent.class,
                 PlayerDisconnectedEvent.class,
                 GetPlayersEvent.class,
-                PlayerMovedEvent.class);
+                PlayerMovedEvent.class,
+                TakeDamageEvent.class);
     }
 
     @Override
@@ -63,6 +62,17 @@ public class ConnectedPlayersRepository implements EventHandler {
             handleGetPlayers((GetPlayersEvent) event);
         } else if (PlayerMovedEvent.class == event.getClass()) {
             handlePlayerMoved((PlayerMovedEvent) event);
+        } else if (TakeDamageEvent.class == event.getClass()) {
+            handleTakeDamage((TakeDamageEvent) event);
+        }
+    }
+
+    private void handleTakeDamage(final TakeDamageEvent event) {
+        TakeDamageEvent.TakeDamageEventPayload payload = event.getPayload();
+        if (!payload.isLocalPlayer()) {
+            if (connectedPlayers.containsKey(payload.getId())) {
+                connectedPlayers.get(payload.getId()).applyDamage(payload.getDamage());
+            }
         }
     }
 
@@ -90,7 +100,12 @@ public class ConnectedPlayersRepository implements EventHandler {
     }
 
     private void handlePlayerDisconnected(final PlayerDisconnectedEvent event) {
-        connectedPlayers.remove(event.getPayload());
+        if (connectedPlayers.containsKey(event.getPayload())) {
+            Gdx.app.postRunnable(() -> {
+                connectedPlayers.get(event.getPayload()).dispose();
+                connectedPlayers.remove(event.getPayload());
+            });
+        }
     }
 
     private void handleNewPlayerConnected(final NewPlayerConnectedEvent event) {

--- a/core/src/com/mygdx/game/repository/LocalPlayerRepository.java
+++ b/core/src/com/mygdx/game/repository/LocalPlayerRepository.java
@@ -1,0 +1,64 @@
+package com.mygdx.game.repository;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.math.Vector2;
+import com.mygdx.game.character.Character;
+import com.mygdx.game.constant.AppConstants;
+import com.mygdx.game.constant.CharacterConstants;
+import com.mygdx.game.event.Event;
+import com.mygdx.game.event.EventBus;
+import com.mygdx.game.event.EventHandler;
+import com.mygdx.game.event.events.TakeDamageEvent;
+import com.mygdx.game.factory.CharacterConfigFactory;
+import com.mygdx.game.factory.TextureConfigFactory;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.Collections;
+import java.util.List;
+
+@Singleton
+public class LocalPlayerRepository implements EventHandler {
+
+    private static final float NEW_PLAYER_X = 1100;
+
+    private static final float NEW_PLAYER_Y = 780;
+
+    private final TextureConfigFactory textureConfigFactory;
+
+    private final CharacterConfigFactory characterConfigFactory;
+
+    private Character player;
+
+    @Inject
+    public LocalPlayerRepository(final TextureConfigFactory textureConfigFactory,
+                                      final CharacterConfigFactory characterConfigFactory,
+                                      final EventBus eventBus) {
+        this.textureConfigFactory = textureConfigFactory;
+        this.characterConfigFactory = characterConfigFactory;
+        eventBus.subscribe(this);
+    }
+
+    public Character initializePlayer(final CharacterConstants.CharacterType characterType, final String characterName) {
+        player = new Character(textureConfigFactory.getTextureConfigForCharacter(characterType),
+                new Vector2(NEW_PLAYER_X, NEW_PLAYER_Y), false, characterName,
+                characterConfigFactory.getCharacterConfigForCharacter(characterType));
+        return player;
+    }
+
+    @Override
+    public List<Class<?>> getSubscribedEventClasses() {
+        return Collections.singletonList(TakeDamageEvent.class);
+    }
+
+    @Override
+    public void handleEvent(Event<?> event) {
+        if (TakeDamageEvent.class == event.getClass()) {
+            TakeDamageEvent.TakeDamageEventPayload payload = ((TakeDamageEvent)event).getPayload();
+            if (payload.isLocalPlayer()) {
+                Gdx.app.log(AppConstants.APP_LOG_TAG, "Taking damage: " + payload.getDamage());
+                player.applyDamage(payload.getDamage());
+            }
+        }
+    }
+}

--- a/core/src/com/mygdx/game/repository/LocalPlayerRepository.java
+++ b/core/src/com/mygdx/game/repository/LocalPlayerRepository.java
@@ -11,6 +11,7 @@ import com.mygdx.game.event.EventHandler;
 import com.mygdx.game.event.events.TakeDamageEvent;
 import com.mygdx.game.factory.CharacterConfigFactory;
 import com.mygdx.game.factory.TextureConfigFactory;
+import lombok.Getter;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -28,6 +29,7 @@ public class LocalPlayerRepository implements EventHandler {
 
     private final CharacterConfigFactory characterConfigFactory;
 
+    @Getter
     private Character player;
 
     @Inject
@@ -42,7 +44,8 @@ public class LocalPlayerRepository implements EventHandler {
     public Character initializePlayer(final CharacterConstants.CharacterType characterType, final String characterName) {
         player = new Character(textureConfigFactory.getTextureConfigForCharacter(characterType),
                 new Vector2(NEW_PLAYER_X, NEW_PLAYER_Y), false, characterName,
-                characterConfigFactory.getCharacterConfigForCharacter(characterType));
+                characterConfigFactory.getCharacterConfigForCharacter(characterType),
+                characterType);
         return player;
     }
 

--- a/core/src/com/mygdx/game/screen/ArenaScreen.java
+++ b/core/src/com/mygdx/game/screen/ArenaScreen.java
@@ -4,20 +4,18 @@ import com.badlogic.gdx.Screen;
 import com.badlogic.gdx.graphics.Camera;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.Batch;
-import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.utils.ScreenUtils;
 import com.mygdx.game.character.Character;
 import com.mygdx.game.client.SocketIOClient;
-import com.mygdx.game.dto.CharacterReadyDto;
-import com.mygdx.game.dto.PlayerMovedDto;
 import com.mygdx.game.constant.AppConstants;
 import com.mygdx.game.constant.CharacterConstants;
 import com.mygdx.game.constant.SocketEventConstants;
-import com.mygdx.game.factory.CharacterConfigFactory;
-import com.mygdx.game.factory.TextureConfigFactory;
+import com.mygdx.game.dto.CharacterReadyDto;
+import com.mygdx.game.dto.PlayerMovedDto;
 import com.mygdx.game.input.ArenaInputHandler;
 import com.mygdx.game.input.InputHandler;
 import com.mygdx.game.repository.ConnectedPlayersRepository;
+import com.mygdx.game.repository.LocalPlayerRepository;
 import lombok.NonNull;
 
 import javax.inject.Inject;
@@ -32,13 +30,11 @@ public class ArenaScreen implements Screen {
 
     private final Camera camera;
 
-    private final TextureConfigFactory textureConfigFactory;
-
     private final SocketIOClient socketIOClient;
 
     private final ConnectedPlayersRepository connectedPlayersRepository;
 
-    private final CharacterConfigFactory characterConfigFactory;
+    private final LocalPlayerRepository localPlayerRepository;
 
     private final Texture background;
 
@@ -51,16 +47,14 @@ public class ArenaScreen implements Screen {
     @Inject
     public ArenaScreen(@NonNull final Batch batch,
                        @NonNull final Camera camera,
-                       @NonNull final TextureConfigFactory textureConfigFactory,
                        @NonNull final SocketIOClient socketIOClient,
                        @NonNull final ConnectedPlayersRepository connectedPlayersRepository,
-                       @NonNull final CharacterConfigFactory characterConfigFactory) {
+                       @NonNull final LocalPlayerRepository localPlayerRepository) {
         this.batch = batch;
         this.camera = camera;
-        this.textureConfigFactory = textureConfigFactory;
         this.socketIOClient = socketIOClient;
         this.connectedPlayersRepository = connectedPlayersRepository;
-        this.characterConfigFactory = characterConfigFactory;
+        this.localPlayerRepository = localPlayerRepository;
         this.background = new Texture("Background/game_background_4.png"); //TODO : Refactor this
     }
 
@@ -69,10 +63,8 @@ public class ArenaScreen implements Screen {
      * @param characterType
      */
     public void initializePlayer(final CharacterConstants.CharacterType characterType, final String characterName) {
-        player = new Character(textureConfigFactory.getTextureConfigForCharacter(characterType),
-                new Vector2(camera.viewportWidth, camera.viewportHeight), false, characterName,
-                characterConfigFactory.getCharacterConfigForCharacter(characterType));
-        inputHandler = new ArenaInputHandler(player, background, connectedPlayersRepository);
+        player = localPlayerRepository.initializePlayer(characterType, characterName);
+        inputHandler = new ArenaInputHandler(player, background, connectedPlayersRepository, socketIOClient);
         CharacterReadyDto dto = CharacterReadyDto.builder()
                 .name(characterName)
                 .character(characterType)

--- a/core/src/com/mygdx/game/screen/ArenaScreen.java
+++ b/core/src/com/mygdx/game/screen/ArenaScreen.java
@@ -58,20 +58,6 @@ public class ArenaScreen implements Screen {
         this.background = new Texture("Background/game_background_4.png"); //TODO : Refactor this
     }
 
-    /**
-     * Initializes the local player. Notifies the server once the player is successfully created.
-     * @param characterType
-     */
-    public void initializePlayer(final CharacterConstants.CharacterType characterType, final String characterName) {
-        player = localPlayerRepository.initializePlayer(characterType, characterName);
-        inputHandler = new ArenaInputHandler(player, background, connectedPlayersRepository, socketIOClient);
-        CharacterReadyDto dto = CharacterReadyDto.builder()
-                .name(characterName)
-                .character(characterType)
-                .build();
-        socketIOClient.emit(SocketEventConstants.PLAYER_READY, dto.toJsonObject());
-    }
-
     @Override
     public void render(float delta) {
         ScreenUtils.clear(1, 1, 1, 1);
@@ -133,6 +119,16 @@ public class ArenaScreen implements Screen {
         }
     }
 
+    private void initializePlayer() {
+        player = localPlayerRepository.getPlayer();
+        inputHandler = new ArenaInputHandler(player, background, connectedPlayersRepository, socketIOClient);
+        CharacterReadyDto dto = CharacterReadyDto.builder()
+                .name(player.getName())
+                .character(player.getCharacterType())
+                .build();
+        socketIOClient.emit(SocketEventConstants.PLAYER_READY, dto.toJsonObject());
+    }
+
     @Override
     public void dispose() {
         player.dispose();
@@ -144,6 +140,7 @@ public class ArenaScreen implements Screen {
 
     @Override
     public void show() {
+        initializePlayer();
     }
 
     @Override

--- a/core/src/com/mygdx/game/screen/CharacterSelectScreen.java
+++ b/core/src/com/mygdx/game/screen/CharacterSelectScreen.java
@@ -20,6 +20,7 @@ import com.mygdx.game.event.events.CharacterSelectedEvent;
 import com.mygdx.game.event.events.SocketConnectedEvent;
 import com.mygdx.game.factory.TextureConfigFactory;
 import com.mygdx.game.model.AnimConfig;
+import com.mygdx.game.repository.LocalPlayerRepository;
 import lombok.NonNull;
 
 import javax.inject.Inject;
@@ -39,6 +40,8 @@ public class CharacterSelectScreen implements Screen, EventHandler {
 
     private final Map<CharacterConstants.CharacterType, TextureRegion> characterAnimMap;
 
+    private final LocalPlayerRepository localPlayerRepository;
+
     private Cell<Image> characterImageCell;
 
     private Cell<TextField> characterNameCell;
@@ -49,7 +52,8 @@ public class CharacterSelectScreen implements Screen, EventHandler {
     public CharacterSelectScreen(@NonNull final EventBus eventBus,
                                  @NonNull final Stage stage,
                                  @Named(AppConstants.CHARACTER_SELECT) @NonNull final Skin skin,
-                                 @NonNull final TextureConfigFactory textureConfigFactory) {
+                                 @NonNull final TextureConfigFactory textureConfigFactory,
+                                 @NonNull final LocalPlayerRepository localPlayerRepository) {
         this.eventBus = eventBus;
         this.stage = stage;
         this.skin = skin;
@@ -59,6 +63,7 @@ public class CharacterSelectScreen implements Screen, EventHandler {
             AnimConfig animConfig = textureConfig.getAnimConfigMap().get(State.IDLE);
             characterAnimMap.put(characterType, textureAtlas.findRegions(animConfig.getName()).get(0));
         });
+        this.localPlayerRepository = localPlayerRepository;
         eventBus.subscribe(this);
     }
 
@@ -105,6 +110,8 @@ public class CharacterSelectScreen implements Screen, EventHandler {
                 if (Objects.isNull(characterNameCell.getActor().getText()) || characterNameCell.getActor().getText().isEmpty()) {
                     Gdx.app.log(AppConstants.APP_LOG_TAG, "Must enter name"); // TODO : Popup error message
                 } else {
+                    localPlayerRepository.initializePlayer(CharacterConstants.CharacterType.values()[currentCharacterIndex],
+                            characterNameCell.getActor().getText());
                     eventBus.publish(CharacterSelectedEvent.builder()
                             .characterSelectedPayload(CharacterSelectedEvent.CharacterSelectedPayload.builder()
                                     .character(CharacterConstants.CharacterType.values()[currentCharacterIndex])


### PR DESCRIPTION
**NOTE:** This change requires https://github.com/sagdutt/Raze-NodeServer/pull/2 to be merged first.

1. Adding logic for attacking and taking damage from other players. When health drops to 0, character plays dead animation.
2. Sending `PlayerDamaged` event to server when local player damages another player. Receiving `TakeDamage` event from server when any connected player or local player takes damage.
3. Storing socket id in `SocketIOClient` to differentiate between local and remote players.
4. Added `LocalPlayerRepository` to store the instance of the local player. Using this to initialize the player when character is selected in `CharacterSelectScreen`.  Getting the player inside `AreaScreen.show()` instead of initializing it.